### PR TITLE
Return ScheduledExecutorService from ConsumerExecutorServiceConfig

### DIFF
--- a/kafka/src/main/java/io/micronaut/configuration/kafka/executor/ConsumerExecutorServiceConfig.java
+++ b/kafka/src/main/java/io/micronaut/configuration/kafka/executor/ConsumerExecutorServiceConfig.java
@@ -40,9 +40,8 @@ public class ConsumerExecutorServiceConfig {
      * @return The executor configurations
      */
     @Singleton
-    @Bean
     @Named(TaskExecutors.MESSAGE_CONSUMER)
     ExecutorConfiguration configuration() {
-        return UserExecutorConfiguration.of(ExecutorType.FIXED, 75);
+        return UserExecutorConfiguration.of(ExecutorType.SCHEDULED, 75);
     }
 }


### PR DESCRIPTION
In line with documented behaviour.

This change should be forward compatible as ScheduledExecutorService is a subtype of ExecutorService and implements all of the base functionality.